### PR TITLE
feat: expose public process_splits helper

### DIFF
--- a/baseball_data_lab/apis/mlb_stats_client.py
+++ b/baseball_data_lab/apis/mlb_stats_client.py
@@ -694,6 +694,23 @@ class MlbStatsClient:
         return f"{STATS_API_BASE_URL}{endpoint}?{urlencode(query_params, safe='[],()')}"
     
 
-# def process_splits(data: List[Dict[str, Any]]) -> pd.DataFrame:
-#     """Compatibility wrapper around :meth:`MlbStatsClient._process_splits`."""
-#     return MlbStatsClient._process_splits(data)
+def process_splits(data: List[Dict[str, Any]]) -> pd.DataFrame:
+    """Public wrapper around :meth:`MlbStatsClient._process_splits`.
+
+    Parameters
+    ----------
+    data : List[Dict[str, Any]]
+        Raw split data returned from the Stats API.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Reformatted split statistics.
+    """
+    return MlbStatsClient._process_splits(data)
+
+
+__all__ = [
+    "MlbStatsClient",
+    "process_splits",
+]


### PR DESCRIPTION
## Summary
- restore a module-level `process_splits` function delegating to `MlbStatsClient._process_splits`
- export `process_splits` in `mlb_stats_client.__all__`

## Testing
- `python - <<'PY'
from baseball_data_lab.apis.mlb_stats_client import process_splits
print(process_splits)
PY`
- `pytest tests/data_viz/test_stats_table.py`


------
https://chatgpt.com/codex/tasks/task_e_68b89ef13e90832696ba296cabe702d5