### PR TITLE
Refactor UnifiedDataClient player stats retrieval

### DIFF
--- a/baseball_data_lab/apis/unified_data_client.py
+++ b/baseball_data_lab/apis/unified_data_client.py
@@ -1,10 +1,14 @@
 import pandas as pd
+from typing import Optional
 
 from baseball_data_lab.apis.web_client import WebClient
 from baseball_data_lab.apis.mlb_stats_client import MlbStatsClient
 from baseball_data_lab.apis.pybaseball_client import PybaseballClient
 from baseball_data_lab.apis.fangraphs_client import FangraphsClient
-from baseball_data_lab.apis.chadwick_register import ChadwickRegister, PlayerSearchClient
+from baseball_data_lab.apis.chadwick_register import (
+    ChadwickRegister,
+    PlayerSearchClient,
+)
 from baseball_data_lab.utils import Utils
 
 
@@ -18,10 +22,15 @@ class UnifiedDataClient:
     #############################
     # FangraphsClient wrappers
     #############################
-    def fetch_batting_stats(
-        self, mlbam_id: int, season: int, fangraphs_team_id: int = None
+
+    def _fetch_player_stats(
+        self,
+        mlbam_id: int,
+        season: int,
+        stat_type: str,
+        fangraphs_team_id: Optional[int] = None,
     ) -> pd.DataFrame:
-        """Fetch batting stats for a player."""
+        """Internal helper to fetch Fangraphs stats for a player."""
         player_fangraphs_id = Utils.get_fangraphs_id(
             mlbam_id=mlbam_id, search_client=self.search_client
         )
@@ -34,11 +43,27 @@ class UnifiedDataClient:
                 player_fangraphs_id = 31781
             else:
                 raise ValueError(f"Invalid Fangraphs ID for player {mlbam_id}.")
+
         return FangraphsClient.fetch_player_stats(
             player_fangraphs_id=player_fangraphs_id,
             season=season,
             fangraphs_team_id=fangraphs_team_id,
-            stat_type="batting",
+            stat_type=stat_type,
+        )
+
+    def fetch_player_stats(
+        self,
+        mlbam_id: int,
+        season: int,
+        stat_type: str,
+        fangraphs_team_id: Optional[int] = None,
+    ) -> pd.DataFrame:
+        """Fetch batting or pitching stats for a player."""
+        return self._fetch_player_stats(
+            mlbam_id=mlbam_id,
+            season=season,
+            stat_type=stat_type,
+            fangraphs_team_id=fangraphs_team_id,
         )
 
     def fetch_batting_leaderboards(self, season: int) -> pd.DataFrame:
@@ -46,29 +71,6 @@ class UnifiedDataClient:
 
     def fetch_batting_leaderboards_as_json(self, season: int):
         return FangraphsClient.fetch_batting_leaderboards_as_json(season)
-
-    def fetch_pitching_stats(
-        self, mlbam_id: int, season: int, fangraphs_team_id: int = None
-    ) -> pd.DataFrame:
-        player_fangraphs_id = Utils.get_fangraphs_id(
-            mlbam_id=mlbam_id, search_client=self.search_client
-        )
-        if player_fangraphs_id == -1:
-            if mlbam_id == 690916:
-                player_fangraphs_id = 30160
-            elif mlbam_id == 695578:
-                player_fangraphs_id = 29518
-            elif mlbam_id == 702616:
-                player_fangraphs_id = 31781
-            else:
-                raise ValueError(f"Invalid Fangraphs ID for player {mlbam_id}.")
-
-        return FangraphsClient.fetch_player_stats(
-            player_fangraphs_id=player_fangraphs_id,
-            season=season,
-            fangraphs_team_id=fangraphs_team_id,
-            stat_type="pitching",
-        )
 
     def fetch_pitching_leaderboards(self, season: int) -> pd.DataFrame:
         return FangraphsClient.fetch_pitching_leaderboards(season)
@@ -126,7 +128,7 @@ class UnifiedDataClient:
         return MlbStatsClient.get_player_teams_for_season(
             player_id, year, group=group, ids_only=ids_only
         )
-    
+
     def get_player_gamelog(self, player_id: int, stat_type: str, season: int):
         return MlbStatsClient.get_player_gamelog(player_id, stat_type, season)
 
@@ -135,15 +137,17 @@ class UnifiedDataClient:
 
     def get_player_mlbam_id(self, player_id: int):
         return MlbStatsClient.get_player_mlbam_id(player_id)
-    
+
     def get_standings_data(self, season: int, league_ids: str) -> pd.DataFrame:
         return MlbStatsClient.get_standings_data(season, league_ids)
-    
+
     def get_team_record_for_season(self, season: int, team_id: int) -> pd.DataFrame:
         return MlbStatsClient.get_team_record_for_season(season, team_id)
-    
-    def get_schedule_for_date_range(self, start_date: str, end_date: str) -> pd.DataFrame:
-        return MlbStatsClient.get_schedule_for_date_range(start_date, end_date) 
+
+    def get_schedule_for_date_range(
+        self, start_date: str, end_date: str
+    ) -> pd.DataFrame:
+        return MlbStatsClient.get_schedule_for_date_range(start_date, end_date)
 
     def get_team_logo_url(self, mlbam_team_id: int) -> str:
         return MlbStatsClient.get_team_logo_url(mlbam_team_id)
@@ -166,8 +170,20 @@ class UnifiedDataClient:
     def fetch_player_stats_career(self, player_id: int):
         return MlbStatsClient.fetch_player_stats_career(player_id)
 
-    def get_leaderboard_data(self, season: int, league_ids: str, team_id: str, group: str, stat_type: str, limit: int, offset: int, sort_order: str) -> pd.DataFrame:
-        return MlbStatsClient.get_leaderboard_data(season, league_ids, team_id, group, stat_type, limit, offset, sort_order)
+    def get_leaderboard_data(
+        self,
+        season: int,
+        league_ids: str,
+        team_id: str,
+        group: str,
+        stat_type: str,
+        limit: int,
+        offset: int,
+        sort_order: str,
+    ) -> pd.DataFrame:
+        return MlbStatsClient.get_leaderboard_data(
+            season, league_ids, team_id, group, stat_type, limit, offset, sort_order
+        )
 
     #############################
     # PybaseballClient wrappers
@@ -201,9 +217,7 @@ class UnifiedDataClient:
     def save_statcast_batter_data(
         self, player_id: int, year: int, file_path: str = None
     ):
-        return PybaseballClient.save_statcast_batter_data(
-            player_id, year, file_path
-        )
+        return PybaseballClient.save_statcast_batter_data(player_id, year, file_path)
 
     def fetch_fangraphs_pitcher_data(
         self, player_name: str, team_fangraphs_id: str, start_year: int, end_year: int
@@ -215,9 +229,7 @@ class UnifiedDataClient:
     def fetch_pitching_splits_leaderboards(
         self, player_bbref: str, season: int
     ) -> pd.DataFrame:
-        return PybaseballClient.fetch_pitching_splits_leaderboards(
-            player_bbref, season
-        )
+        return PybaseballClient.fetch_pitching_splits_leaderboards(player_bbref, season)
 
     def fetch_statcast_pitcher_data(
         self, pitcher_id: int, start_date: str, end_date: str
@@ -236,14 +248,10 @@ class UnifiedDataClient:
     def save_statcast_pitcher_data(
         self, player_id: int, year: int, file_path: str = None
     ):
-        return PybaseballClient.save_statcast_pitcher_data(
-            player_id, year, file_path
-        )
+        return PybaseballClient.save_statcast_pitcher_data(player_id, year, file_path)
 
     def fetch_team_schedule_and_record(self, team_abbrev: str, season: int):
-        return PybaseballClient.fetch_team_schedule_and_record(
-            team_abbrev, season
-        )
+        return PybaseballClient.fetch_team_schedule_and_record(team_abbrev, season)
 
     #############################
     # WebClient wrappers
@@ -263,15 +271,7 @@ class UnifiedDataClient:
         )
 
     def lookup_player_by_id(self, player_id: int):
-        return self.search_client.playerid_reverse_lookup(
-            [player_id], key_type="mlbam"
-        )
+        return self.search_client.playerid_reverse_lookup([player_id], key_type="mlbam")
 
     def playerid_reverse_lookup(self, player_id, key_type="mlbam"):
-        return self.search_client.playerid_reverse_lookup(
-            [player_id], key_type="mlbam"
-        )
-    
-    
-
-
+        return self.search_client.playerid_reverse_lookup([player_id], key_type="mlbam")

--- a/baseball_data_lab/player/player.py
+++ b/baseball_data_lab/player/player.py
@@ -18,81 +18,106 @@ logger = logging.getLogger(__name__)
 
 
 class Player:
-    def __init__(self, mlbam_id: Optional[int] = None, data_client: Optional[UnifiedDataClient] = None):
+    def __init__(
+        self,
+        mlbam_id: Optional[int] = None,
+        data_client: Optional[UnifiedDataClient] = None,
+    ):
         """
         Initializes a Player instance.
-        
+
         :param mlbam_id: MLB Advanced Media ID
         :param data_client: UnifiedDataClient instance; if not provided, a default one is used.
         """
         self.mlbam_id = mlbam_id
         self.bbref_id: Optional[str] = None
         self.player_info: PlayerInfo = PlayerInfo()
-        self.player_bio: PlayerBio = PlayerBio() 
+        self.player_bio: PlayerBio = PlayerBio()
         self.current_team: Team = Team(data_client=data_client)
         self.player_stats: Optional[Any] = None
         self.player_splits_stats: Optional[Any] = None
         self.statcast_data: Optional[Any] = None
-        self.data_client: UnifiedDataClient = data_client if data_client else UnifiedDataClient()
+        self.data_client: UnifiedDataClient = (
+            data_client if data_client else UnifiedDataClient()
+        )
         self.lookup_client: PlayerLookup = PlayerLookup(data_client=self.data_client)
 
     def load_stats_for_season(self, season: int) -> None:
         """
         Fetches and sets the player's season statistics.
         """
-        if self.player_info.primary_position == 'P':
-            self.player_stats = self.data_client.fetch_pitching_stats(
+        if self.player_info.primary_position == "P":
+            self.player_stats = self.data_client.fetch_player_stats(
                 mlbam_id=self.mlbam_id,
-                season=season)
-            self.player_splits_stats = self.data_client.fetch_pitching_splits(self.mlbam_id, season=season)
+                season=season,
+                stat_type="pitching",
+            )
+            self.player_splits_stats = self.data_client.fetch_pitching_splits(
+                self.mlbam_id, season=season
+            )
         else:
-            self.player_stats = self.data_client.fetch_batting_stats(
+            self.player_stats = self.data_client.fetch_player_stats(
                 mlbam_id=self.mlbam_id,
-                season=season)
-            self.player_splits_stats = self.data_client.fetch_batting_splits(self.mlbam_id, season=season)
+                season=season,
+                stat_type="batting",
+            )
+            self.player_splits_stats = self.data_client.fetch_batting_splits(
+                self.mlbam_id, season=season
+            )
 
     def load_statcast_data(self, start_date: str, end_date: str) -> None:
         """
         Fetches and sets the player's Statcast data.
         """
-        if self.player_info.primary_position == 'P':
-            self.statcast_data = self.data_client.fetch_statcast_pitcher_data(self.mlbam_id, start_date, end_date)
+        if self.player_info.primary_position == "P":
+            self.statcast_data = self.data_client.fetch_statcast_pitcher_data(
+                self.mlbam_id, start_date, end_date
+            )
         else:
-            self.statcast_data = self.data_client.fetch_statcast_batter_data(self.mlbam_id, start_date, end_date)
+            self.statcast_data = self.data_client.fetch_statcast_batter_data(
+                self.mlbam_id, start_date, end_date
+            )
 
     @classmethod
-    def create_from_mlb(cls, *, mlbam_id: Optional[int] = None, player_name: Optional[str] = None,
-                        data_client: Optional[UnifiedDataClient] = None) -> Optional["Player"]:
+    def create_from_mlb(
+        cls,
+        *,
+        mlbam_id: Optional[int] = None,
+        player_name: Optional[str] = None,
+        data_client: Optional[UnifiedDataClient] = None,
+    ) -> Optional["Player"]:
         """
         Factory method to create a Player instance using MLBAM ID or player_name.
         """
         player = Player(data_client=data_client)
         if player_name:
-            #logger.info(f"Creating player: {player_name}")
+            # logger.info(f"Creating player: {player_name}")
             player_data = player.lookup_client.lookup_player(player_name)
             if player_data is None:
                 logger.error(f"Could not find player data for: {player_name}")
                 return None
-            mlbam_id = player_data.get('key_mlbam')
+            mlbam_id = player_data.get("key_mlbam")
             # If mlbam_id is a list, consider taking the first element.
             if isinstance(mlbam_id, list):
                 logger.debug(f"mlbam_id list received: {mlbam_id}")
                 mlbam_id = mlbam_id[0]
-            bbref_id = player_data.get('key_bbref')
+            bbref_id = player_data.get("key_bbref")
             if not mlbam_id:
                 raise ValueError(f"Could not find MLBAM ID for player: {player_name}")
 
         elif mlbam_id:
             player_data = player.lookup_client.lookup_player(player_id=mlbam_id)
-            #logger.info(f"Creating player: {player_data}")
-            first = player_data.get('name_first', '').capitalize()
-            last = player_data.get('name_last', '').capitalize()
+            # logger.info(f"Creating player: {player_data}")
+            first = player_data.get("name_first", "").capitalize()
+            last = player_data.get("name_last", "").capitalize()
             player_name = f"{first} {last}"
-            bbref_id = player_data.get('key_bbref')
+            bbref_id = player_data.get("key_bbref")
             if not player_name:
                 raise ValueError(f"Could not find player name for MLBAM ID: {mlbam_id}")
         else:
-            raise ValueError("At least one of 'mlbam_id' or 'player_name' must be provided.")
+            raise ValueError(
+                "At least one of 'mlbam_id' or 'player_name' must be provided."
+            )
 
         player.mlbam_id = mlbam_id  # cls(mlbam_id, data_client=data_client)
         player.bbref_id = bbref_id
@@ -106,9 +131,11 @@ class Player:
         """
         Sets the current team based on MLB player info.
         """
-        team_id = mlb_player_info.get('currentTeam', {}).get('id')
+        team_id = mlb_player_info.get("currentTeam", {}).get("id")
         if team_id:
-            self.current_team = Team.create_from_mlb(team_id=team_id, data_client=self.data_client)
+            self.current_team = Team.create_from_mlb(
+                team_id=team_id, data_client=self.data_client
+            )
         else:
             logger.warning("No current team information available.")
 
@@ -119,20 +146,20 @@ class Player:
         headshot = self.data_client.fetch_player_headshot(self.mlbam_id)
         img = Image.open(BytesIO(headshot))
         return img
-    
+
     def save_statcast_data(self, year: int = 2024) -> None:
         """
         Saves the player's statcast data to a CSV file based on their position.
         """
         name_slug = self.player_bio.full_name.lower().replace(" ", "_")
-        if self.player_info.primary_position == 'P':
-            file_path = f'{STATCAST_DATA_DIR}/{year}/statcast_data/{self.current_team.abbrev}/pitching/statcast_data_{name_slug}_{year}.csv'
+        if self.player_info.primary_position == "P":
+            file_path = f"{STATCAST_DATA_DIR}/{year}/statcast_data/{self.current_team.abbrev}/pitching/statcast_data_{name_slug}_{year}.csv"
             self.data_client.save_statcast_pitcher_data(self.mlbam_id, year, file_path)
         else:
-            file_path = f'{STATCAST_DATA_DIR}/{year}/statcast_data/{self.current_team.abbrev}/batting/statcast_data_{name_slug}_{year}.csv'
+            file_path = f"{STATCAST_DATA_DIR}/{year}/statcast_data/{self.current_team.abbrev}/batting/statcast_data_{name_slug}_{year}.csv"
             self.data_client.save_statcast_batter_data(self.mlbam_id, year, file_path)
         logger.info(f"Statcast data saved to {file_path}")
-    
+
     def to_json(self) -> Dict[str, Any]:
         """
         Exports player data to a JSON-friendly dictionary.
@@ -140,7 +167,7 @@ class Player:
         return {
             "mlbam_id": self.mlbam_id,
             "bbref_id": self.bbref_id,
-            "team_name": self.current_team.name,  
+            "team_name": self.current_team.name,
             "player_bio": self.player_bio.to_json(),
             "player_info": self.player_info.to_json(),
         }

--- a/baseball_data_lab/stats/save_season_stats.py
+++ b/baseball_data_lab/stats/save_season_stats.py
@@ -58,14 +58,41 @@ class SeasonStatsDownloader:
             self.team_ids = self.get_team_ids_by_league(league)
         else:
             self.team_ids = [
-                109,144,110,111,112,145,113,114,115,116,
-                117,118,108,119,146,158,142,121,147,133,
-                143,134,135,137,136,138,139,140,141,120
+                109,
+                144,
+                110,
+                111,
+                112,
+                145,
+                113,
+                114,
+                115,
+                116,
+                117,
+                118,
+                108,
+                119,
+                146,
+                158,
+                142,
+                121,
+                147,
+                133,
+                143,
+                134,
+                135,
+                137,
+                136,
+                138,
+                139,
+                140,
+                141,
+                120,
             ]
 
-        self.max_workers    = max_workers
+        self.max_workers = max_workers
         self.retry_attempts = retry_attempts
-        self.chunk_size     = chunk_size
+        self.chunk_size = chunk_size
 
         self.statuses: Dict[str, List[str]] = {
             "success": [],
@@ -168,7 +195,7 @@ class SeasonStatsDownloader:
 
     @staticmethod
     def _build_player_tasks(
-        teams_and_rosters: List[Tuple[int, pd.DataFrame]]
+        teams_and_rosters: List[Tuple[int, pd.DataFrame]],
     ) -> List[int]:
         """Return a de-duplicated list of player IDs from the supplied rosters."""
         ids = {
@@ -178,9 +205,7 @@ class SeasonStatsDownloader:
         }
         return list(ids)
 
-    def _combine_and_clean_dfs(
-        self, dfs: List[pd.DataFrame]
-    ) -> Optional[pd.DataFrame]:
+    def _combine_and_clean_dfs(self, dfs: List[pd.DataFrame]) -> Optional[pd.DataFrame]:
         """Drop empty columns, concatenate, and sanitize text columns."""
         valid = [df for df in dfs if not df.empty]
         cleaned = [df.dropna(axis=1, how="all") for df in valid]
@@ -189,7 +214,6 @@ class SeasonStatsDownloader:
 
         combined = pd.concat(cleaned, ignore_index=True, sort=False)
         return self._sanitize_text_df(combined)
-
 
     def download(self, *, output_file: Optional[str] = None) -> None:
         """Main entry point to download and persist season stats."""
@@ -220,8 +244,6 @@ class SeasonStatsDownloader:
 
         self._print_summary(output_file)
 
-
-
     def _fetch_player_stats(
         self,
         mlbam_id: int,
@@ -237,26 +259,24 @@ class SeasonStatsDownloader:
         for attempt in range(1, self.retry_attempts + 1):
             try:
                 player = Player.create_from_mlb(
-                    mlbam_id=mlbam_id,
-                    data_client=self.client
+                    mlbam_id=mlbam_id, data_client=self.client
                 )
                 if not player:
                     raise PlayerNotFoundError(f"No player for id {mlbam_id}")
-                safe_name = getattr(getattr(player, "player_bio", None), "full_name", safe_name)
+                safe_name = getattr(
+                    getattr(player, "player_bio", None), "full_name", safe_name
+                )
 
                 pos = player.player_info.primary_position
                 if self.player_type == "pitchers" and pos != "P":
                     raise PositionMismatchError(f"{mlbam_id} is not a pitcher")
                 if self.player_type == "batters" and pos == "P":
-                    raise PositionMismatchError(f"{mlbam_id} is a pitcher, not a batter")
+                    raise PositionMismatchError(
+                        f"{mlbam_id} is a pitcher, not a batter"
+                    )
 
-                fetch_fn = (
-                    self.client.fetch_pitching_stats
-                    if pos == "P"
-                    else self.client.fetch_batting_stats
-                )
-
-                group = "pitching" if pos == "P" else "batting"
+                stat_type = "pitching" if pos == "P" else "batting"
+                group = stat_type
                 team_ids = self.client.get_player_teams_for_season(
                     mlbam_id, self.season, group=group, ids_only=True
                 )
@@ -265,10 +285,13 @@ class SeasonStatsDownloader:
 
                 team_dfs: List[pd.DataFrame] = []
                 for team_id in team_ids:
-                    fg_id = self.team_id_map.get(team_id) if team_id is not None else None
-                    stats = fetch_fn(
+                    fg_id = (
+                        self.team_id_map.get(team_id) if team_id is not None else None
+                    )
+                    stats = self.client.fetch_player_stats(
                         mlbam_id=mlbam_id,
                         season=self.season,
+                        stat_type=stat_type,
                         fangraphs_team_id=fg_id,
                     )
                     # Drop columns with no data and skip entirely empty or all-NA frames
@@ -324,8 +347,8 @@ class SeasonStatsDownloader:
             index=False,
             quoting=csv.QUOTE_MINIMAL,
             quotechar='"',
-            escapechar='\\',
-            lineterminator='\n',
+            escapechar="\\",
+            lineterminator="\n",
         )
         logger.debug(f"Wrote {len(combined)} rows to {filename}")
 
@@ -340,11 +363,10 @@ class SeasonStatsDownloader:
             index=False,
             quoting=csv.QUOTE_MINIMAL,
             quotechar='"',
-            escapechar='\\',
-            lineterminator='\n',
+            escapechar="\\",
+            lineterminator="\n",
         )
         logger.debug(f"Wrote {len(combined)} rows to {filename}")
-
 
     def _print_summary(self, filename: str) -> None:
         total = sum(len(lst) for lst in self.statuses.values())

--- a/tests/player/test_player.py
+++ b/tests/player/test_player.py
@@ -11,21 +11,18 @@ from baseball_data_lab.player.player import Player
 class DummyDataClient:
     def __init__(self):
         self.fetched_info = None
-        self.pitching_stats = {'wins': 10}
-        self.batting_stats = {'hits': 50}
-        self.pitching_splits = {'splits': 'pitch'}
-        self.batting_splits = {'splits': 'bat'}
-        self.statcast_pitcher = [{'pitch_data': 1}]
-        self.statcast_batter = [{'bat_data': 2}]
+        self.pitching_stats = {"wins": 10}
+        self.batting_stats = {"hits": 50}
+        self.pitching_splits = {"splits": "pitch"}
+        self.batting_splits = {"splits": "bat"}
+        self.statcast_pitcher = [{"pitch_data": 1}]
+        self.statcast_batter = [{"bat_data": 2}]
         self.headshot_bytes = BytesIO()
-        Image.new('RGB', (1, 1)).save(self.headshot_bytes, format='PNG')
+        Image.new("RGB", (1, 1)).save(self.headshot_bytes, format="PNG")
         self.headshot_bytes = self.headshot_bytes.getvalue()
 
-    def fetch_pitching_stats(self, mlbam_id, season):
-        return self.pitching_stats
-
-    def fetch_batting_stats(self, mlbam_id, season):
-        return self.batting_stats
+    def fetch_player_stats(self, mlbam_id, season, stat_type, fangraphs_team_id=None):
+        return self.pitching_stats if stat_type == "pitching" else self.batting_stats
 
     def fetch_pitching_splits(self, mlbam_id, season):
         return self.pitching_splits
@@ -40,7 +37,11 @@ class DummyDataClient:
         return self.statcast_batter
 
     def fetch_player_info(self, mlbam_id):
-        self.fetched_info = {'name_first': 'john', 'name_last': 'doe', 'currentTeam': {'id': 99}}
+        self.fetched_info = {
+            "name_first": "john",
+            "name_last": "doe",
+            "currentTeam": {"id": 99},
+        }
         return self.fetched_info
 
     def fetch_player_headshot(self, mlbam_id):
@@ -88,28 +89,28 @@ class DummyPlayerInfo:
 
     @classmethod
     def from_mlb_info(cls, info):
-        primary_position = 'P' if info.get('primary_position', 'P') == 'P' else 'H'
+        primary_position = "P" if info.get("primary_position", "P") == "P" else "H"
         return cls(primary_position=primary_position)
 
     def to_json(self):
-        return {'info': True}
+        return {"info": True}
 
 
 class DummyPlayerBio:
     def __init__(self):
-        self.full_name = 'John Doe'
+        self.full_name = "John Doe"
 
     def set_from_mlb_info(self, info):
         self.full_name = f"{info['name_first']} {info['name_last']}"
 
     def to_json(self):
-        return {'bio': True}
+        return {"bio": True}
 
 
 class DummyTeam:
     def __init__(self, data_client=None):
-        self.name = 'Fake Team'
-        self.abbrev = 'FTM'
+        self.name = "Fake Team"
+        self.abbrev = "FTM"
 
     @classmethod
     def create_from_mlb(cls, team_id, data_client=None):
@@ -119,12 +120,18 @@ class DummyTeam:
 @pytest.fixture(autouse=True)
 def patch_dependencies(monkeypatch, tmp_path):
     # Patch data_client, lookup_client, PlayerInfo, PlayerBio, Team, STATCAST_DATA_DIR
-    monkeypatch.setattr(player_module, 'STATCAST_DATA_DIR', str(tmp_path))
-    monkeypatch.setattr(player_module, 'UnifiedDataClient', lambda: DummyDataClient())
-    monkeypatch.setattr(player_module, 'PlayerLookup', lambda data_client=None: DummyLookupClient(return_data={'key_mlbam': 1, 'key_bbref': 'BB'}))
-    monkeypatch.setattr(player_module, 'PlayerInfo', DummyPlayerInfo)
-    monkeypatch.setattr(player_module, 'PlayerBio', DummyPlayerBio)
-    monkeypatch.setattr(player_module, 'Team', DummyTeam)
+    monkeypatch.setattr(player_module, "STATCAST_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(player_module, "UnifiedDataClient", lambda: DummyDataClient())
+    monkeypatch.setattr(
+        player_module,
+        "PlayerLookup",
+        lambda data_client=None: DummyLookupClient(
+            return_data={"key_mlbam": 1, "key_bbref": "BB"}
+        ),
+    )
+    monkeypatch.setattr(player_module, "PlayerInfo", DummyPlayerInfo)
+    monkeypatch.setattr(player_module, "PlayerBio", DummyPlayerBio)
+    monkeypatch.setattr(player_module, "Team", DummyTeam)
 
 
 def test_init_default():
@@ -140,7 +147,7 @@ def test_init_default():
 
 def test_load_stats_for_season_pitcher():
     player = Player(mlbam_id=123)
-    player.player_info.primary_position = 'P'
+    player.player_info.primary_position = "P"
     player.load_stats_for_season(2021)
     assert player.player_stats == player.data_client.pitching_stats
     assert player.player_splits_stats == player.data_client.pitching_splits
@@ -148,7 +155,7 @@ def test_load_stats_for_season_pitcher():
 
 def test_load_stats_for_season_batter():
     player = Player(mlbam_id=456)
-    player.player_info.primary_position = 'H'
+    player.player_info.primary_position = "H"
     player.load_stats_for_season(2021)
     assert player.player_stats == player.data_client.batting_stats
     assert player.player_splits_stats == player.data_client.batting_splits
@@ -156,51 +163,65 @@ def test_load_stats_for_season_batter():
 
 def test_load_statcast_data_pitcher():
     player = Player(mlbam_id=789)
-    player.player_info.primary_position = 'P'
-    player.load_statcast_data('2021-01-01', '2021-12-31')
+    player.player_info.primary_position = "P"
+    player.load_statcast_data("2021-01-01", "2021-12-31")
     assert player.statcast_data == player.data_client.statcast_pitcher
 
 
 def test_load_statcast_data_batter():
     player = Player(mlbam_id=789)
-    player.player_info.primary_position = 'H'
-    player.load_statcast_data('2021-01-01', '2021-12-31')
+    player.player_info.primary_position = "H"
+    player.load_statcast_data("2021-01-01", "2021-12-31")
     assert player.statcast_data == player.data_client.statcast_batter
 
 
 def test_create_from_mlb_with_name():
     # Using patched lookup_client to return valid data
-    player = Player.create_from_mlb(player_name='John Doe')
+    player = Player.create_from_mlb(player_name="John Doe")
     assert isinstance(player, Player)
     assert player.mlbam_id == 1
-    assert player.bbref_id == 'BB'
+    assert player.bbref_id == "BB"
     # After creation, player_info and player_bio should have been set
-    assert player.player_info.primary_position in ('P', 'H')
-    assert player.player_bio.full_name in ('john doe', 'John Doe')
+    assert player.player_info.primary_position in ("P", "H")
+    assert player.player_bio.full_name in ("john doe", "John Doe")
 
 
 def test_create_from_mlb_with_invalid_name(monkeypatch):
     # Patch lookup_client to return None
-    monkeypatch.setattr(player_module, 'PlayerLookup', lambda data_client=None: DummyLookupClient(return_data=None))
-    player = Player.create_from_mlb(player_name='Jane Doe')
+    monkeypatch.setattr(
+        player_module,
+        "PlayerLookup",
+        lambda data_client=None: DummyLookupClient(return_data=None),
+    )
+    player = Player.create_from_mlb(player_name="Jane Doe")
     assert player is None
 
 
 def test_create_from_mlb_with_id(monkeypatch):
     # Patch lookup_client to use id branch
-    monkeypatch.setattr(player_module, 'PlayerLookup', lambda data_client=None: DummyLookupClient(return_data={'name_first': 'jane', 'name_last': 'smith', 'key_bbref': 'BB2'}))
+    monkeypatch.setattr(
+        player_module,
+        "PlayerLookup",
+        lambda data_client=None: DummyLookupClient(
+            return_data={"name_first": "jane", "name_last": "smith", "key_bbref": "BB2"}
+        ),
+    )
     player = Player.create_from_mlb(mlbam_id=999)
     assert isinstance(player, Player)
     assert player.mlbam_id == 999
-    assert player.bbref_id == 'BB2'
+    assert player.bbref_id == "BB2"
 
 
 def test_set_team_no_info(caplog):
     player = Player(mlbam_id=123)
     # fetch_player_info gives currentTeam id, so override fetched_info to no id
-    player.data_client.fetched_info = {'name_first': 'x', 'name_last': 'y', 'currentTeam': {}}
+    player.data_client.fetched_info = {
+        "name_first": "x",
+        "name_last": "y",
+        "currentTeam": {},
+    }
     player.set_team(player.data_client.fetched_info)
-    assert 'No current team information available' in caplog.text
+    assert "No current team information available" in caplog.text
 
 
 def test_get_headshot():
@@ -212,28 +233,34 @@ def test_get_headshot():
 
 def test_save_statcast_data(tmp_path):
     player = Player(mlbam_id=222)
-    player.player_info.primary_position = 'H'
-    player.player_bio.full_name = 'Jane Doe'
-    player.current_team.abbrev = 'JTD'
+    player.player_info.primary_position = "H"
+    player.player_bio.full_name = "Jane Doe"
+    player.current_team.abbrev = "JTD"
     player.save_statcast_data(year=2022)
     # Check that file was created
-    expected = tmp_path / '2022' / 'statcast_data' / 'JTD' / 'batting' / 'statcast_data_jane_doe_2022.csv'
+    expected = (
+        tmp_path
+        / "2022"
+        / "statcast_data"
+        / "JTD"
+        / "batting"
+        / "statcast_data_jane_doe_2022.csv"
+    )
     assert expected.exists()
 
 
 def test_to_json():
     player = Player(mlbam_id=333)
-    player.bbref_id = 'BREF'
-    player.current_team.name = 'TeamX'
+    player.bbref_id = "BREF"
+    player.current_team.name = "TeamX"
     # Monkeypatch to_json methods
-    player.player_bio.to_json = lambda: {'bio_test': True}
-    player.player_info.to_json = lambda: {'info_test': True}
+    player.player_bio.to_json = lambda: {"bio_test": True}
+    player.player_info.to_json = lambda: {"info_test": True}
     result = player.to_json()
     assert result == {
         "mlbam_id": 333,
-        "bbref_id": 'BREF',
-        "team_name": 'TeamX',
-        "player_bio": {'bio_test': True},
-        "player_info": {'info_test': True},
+        "bbref_id": "BREF",
+        "team_name": "TeamX",
+        "player_bio": {"bio_test": True},
+        "player_info": {"info_test": True},
     }
-

--- a/tests/stats/test_save_season_stats.py
+++ b/tests/stats/test_save_season_stats.py
@@ -12,7 +12,7 @@ def test_get_team_ids_by_league(tmp_path, monkeypatch):
     teams = [
         {"mlbam_team_id": 1, "league": "AL"},
         {"mlbam_team_id": 2, "league": "NL"},
-        {"mlbam_team_id": 3, "league": "AL"}
+        {"mlbam_team_id": 3, "league": "AL"},
     ]
     (data_dir / "mlb_teams.json").write_text(json.dumps(teams))
     monkeypatch.setattr(save_season_stats, "DATA_DIR", str(data_dir))
@@ -37,11 +37,8 @@ class DummyClient:
         self.pitch_df = pd.DataFrame({"wins": [1]})
         self.bat_df = pd.DataFrame({"hits": [5]})
 
-    def fetch_pitching_stats(self, mlbam_id, season, fangraphs_team_id=None):
-        return self.pitch_df
-
-    def fetch_batting_stats(self, mlbam_id, season, fangraphs_team_id=None):
-        return self.bat_df
+    def fetch_player_stats(self, mlbam_id, season, stat_type, fangraphs_team_id=None):
+        return self.pitch_df if stat_type == "pitching" else self.bat_df
 
     def get_player_teams_for_season(self, player_id, year, group=None, ids_only=False):
         return [109]
@@ -66,7 +63,11 @@ def test_fetch_player_stats_success(monkeypatch, tmp_path):
     client = DummyClient()
     downloader = SeasonStatsDownloader(season=2024, output_dir=str(tmp_path))
     downloader.client = client
-    monkeypatch.setattr(save_season_stats.Player, "create_from_mlb", lambda mlbam_id, data_client=None: DummyPlayer("P"))
+    monkeypatch.setattr(
+        save_season_stats.Player,
+        "create_from_mlb",
+        lambda mlbam_id, data_client=None: DummyPlayer("P"),
+    )
     df = downloader._fetch_player_stats(1)
     assert isinstance(df, pd.DataFrame)
     assert df["mlbam_id"].iloc[0] == 1
@@ -76,9 +77,15 @@ def test_fetch_player_stats_success(monkeypatch, tmp_path):
 
 def test_fetch_player_stats_position_mismatch(monkeypatch, tmp_path):
     client = DummyClient()
-    downloader = SeasonStatsDownloader(season=2024, output_dir=str(tmp_path), player_type="batters")
+    downloader = SeasonStatsDownloader(
+        season=2024, output_dir=str(tmp_path), player_type="batters"
+    )
     downloader.client = client
-    monkeypatch.setattr(save_season_stats.Player, "create_from_mlb", lambda mlbam_id, data_client=None: DummyPlayer("P"))
+    monkeypatch.setattr(
+        save_season_stats.Player,
+        "create_from_mlb",
+        lambda mlbam_id, data_client=None: DummyPlayer("P"),
+    )
     result = downloader._fetch_player_stats(2)
     assert result is None
     assert downloader.statuses["position_mismatch"] == ["Dummy Player"]


### PR DESCRIPTION
## Summary
- add private `_fetch_player_stats` helper wrapping Fangraphs calls
- expose `fetch_player_stats` with `stat_type` and update consumers
- adapt tests for unified stat fetch API

## Testing
- `pytest` *(fails: AssertionError: Expected result to be a pandas DataFrame)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f5e250cc8326b18810c851011f7c