### PR TITLE
refactor: unify leaderboard fetching

### DIFF
--- a/baseball_data_lab/apis/unified_data_client.py
+++ b/baseball_data_lab/apis/unified_data_client.py
@@ -66,23 +66,26 @@ class UnifiedDataClient:
             fangraphs_team_id=fangraphs_team_id,
         )
 
-    def fetch_batting_leaderboards(self, season: int) -> pd.DataFrame:
-        return FangraphsClient.fetch_batting_leaderboards(season)
+    def _fetch_leaderboards(
+        self, season: int, stat_type: str, as_json: bool = False
+    ):
+        """Internal helper to fetch Fangraphs leaderboards."""
+        if as_json:
+            if stat_type == "pitching":
+                return FangraphsClient.fetch_pitching_leaderboards_as_json(season)
+            if stat_type == "batting":
+                return FangraphsClient.fetch_batting_leaderboards_as_json(season)
+            raise ValueError("Invalid stat_type. Must be 'pitching' or 'batting'")
+        return FangraphsClient.fetch_leaderboards(season, stat_type)
 
-    def fetch_batting_leaderboards_as_json(self, season: int):
-        return FangraphsClient.fetch_batting_leaderboards_as_json(season)
-
-    def fetch_pitching_leaderboards(self, season: int) -> pd.DataFrame:
-        return FangraphsClient.fetch_pitching_leaderboards(season)
-
-    def fetch_pitching_leaderboards_as_json(self, season: int):
-        return FangraphsClient.fetch_pitching_leaderboards_as_json(season)
+    def fetch_leaderboards(
+        self, season: int, stat_type: str, as_json: bool = False
+    ):
+        """Fetch batting or pitching leaderboards."""
+        return self._fetch_leaderboards(season, stat_type, as_json=as_json)
 
     def fetch_team_players(self, team_id: int, season: int):
         return FangraphsClient.fetch_team_players(team_id, season)
-
-    def fetch_leaderboards(self, season: int, stat_type: str) -> pd.DataFrame:
-        return FangraphsClient.fetch_leaderboards(season, stat_type)
 
     #############################
     # MlbStatsClient wrappers

--- a/examples/save_fangraphs_leaderboards.py
+++ b/examples/save_fangraphs_leaderboards.py
@@ -36,10 +36,10 @@ def fetch_and_save_leaderboards(season):
 
     try:
         data_client = UnifiedDataClient()
-        batting_data = data_client.fetch_batting_leaderboards_as_json(season)
+        batting_data = data_client.fetch_leaderboards(season, "batting", as_json=True)
         save_data_to_json(BATTING_FILE_PATH, batting_data)
 
-        pitching_data = data_client.fetch_pitching_leaderboards_as_json(season)
+        pitching_data = data_client.fetch_leaderboards(season, "pitching", as_json=True)
         save_data_to_json(PITCHING_FILE_PATH, pitching_data)
     except Exception as e:
         print(f"Error fetching leaderboard data for season {season}: {e}")


### PR DESCRIPTION
## Summary
- add _fetch_leaderboards helper to UnifiedDataClient
- expose single fetch_leaderboards method with optional JSON output
- update example to use consolidated API

## Testing
- `pytest` *(fails: AssertionError expected DataFrame)*

------
https://chatgpt.com/codex/tasks/task_e_68b90275a43c832682e0007c771bdecf