### PR TITLE
Refactor summary sheets with player base class

### DIFF
--- a/baseball_data_lab/summary_sheets/__init__.py
+++ b/baseball_data_lab/summary_sheets/__init__.py
@@ -1,6 +1,7 @@
 """Summary sheet utilities."""
 
 from .base_sheet import BaseSheet
+from .player_summary_sheet import PlayerSummarySheet
 from .batter_summary_sheet import BatterSummarySheet
 from .pitcher_summary_sheet import PitcherSummarySheet
 from .team_batting_sheet import TeamBattingSheet
@@ -8,6 +9,7 @@ from .team_pitching_sheet import TeamPitchingSheet
 
 __all__ = [
     "BaseSheet",
+    "PlayerSummarySheet",
     "BatterSummarySheet",
     "PitcherSummarySheet",
     "TeamBattingSheet",

--- a/baseball_data_lab/summary_sheets/batter_summary_sheet.py
+++ b/baseball_data_lab/summary_sheets/batter_summary_sheet.py
@@ -4,16 +4,13 @@ from baseball_data_lab.player.player import Player
 from baseball_data_lab.stats.stats_display import StatsDisplay
 from baseball_data_lab.data_viz.batting_spray_chart import BattingSprayChart
 from baseball_data_lab.constants import statcast_events
-from baseball_data_lab.summary_sheets.base_sheet import BaseSheet
+from baseball_data_lab.summary_sheets.player_summary_sheet import PlayerSummarySheet
 
 
-class BatterSummarySheet(BaseSheet):
+class BatterSummarySheet(PlayerSummarySheet):
 
     def __init__(self, player: Player, season: int):
-        super().__init__(season)
-        self.player = player
-        self.player.load_stats_for_season(season)
-        self.player.load_statcast_data(self.start_date, self.end_date)
+        super().__init__(player, season)
         self.columns_count = 8
         self.rows_count = 8
         self.height_ratios = [2, 20, 5, 5, 16, 46, 1, 8]

--- a/baseball_data_lab/summary_sheets/pitcher_summary_sheet.py
+++ b/baseball_data_lab/summary_sheets/pitcher_summary_sheet.py
@@ -10,17 +10,14 @@ from baseball_data_lab.data_viz.pitch_break_plot import PitchBreakPlot
 from baseball_data_lab.data_viz.pitch_breakdown_table import PitchBreakdownTable
 from baseball_data_lab.constants import swing_code, whiff_code
 from baseball_data_lab.config.paths import DATA_DIR
-from baseball_data_lab.summary_sheets.base_sheet import BaseSheet
+from baseball_data_lab.summary_sheets.player_summary_sheet import PlayerSummarySheet
 from baseball_data_lab.apis.local_data_client import LocalDataClient
 
 
-class PitcherSummarySheet(BaseSheet):
+class PitcherSummarySheet(PlayerSummarySheet):
 
     def __init__(self, player: Player, season: int):
-        super().__init__(season)
-        self.player = player
-        self.player.load_stats_for_season(season)
-        self.player.load_statcast_data(self.start_date, self.end_date)
+        super().__init__(player, season)
         self.league_pitch_averages = self.local_data_client.get_statcast_league_pitching(season)
         self.columns_count = 8
         self.rows_count = 10

--- a/baseball_data_lab/summary_sheets/player_summary_sheet.py
+++ b/baseball_data_lab/summary_sheets/player_summary_sheet.py
@@ -1,0 +1,35 @@
+"""Base classes for player summary sheets."""
+
+from baseball_data_lab.player.player import Player
+from baseball_data_lab.apis.unified_data_client import UnifiedDataClient
+
+from .base_sheet import BaseSheet
+
+
+class PlayerSummarySheet(BaseSheet):
+    """Shared initialization logic for player summary sheets."""
+
+    def __init__(
+        self,
+        player: Player,
+        season: int,
+        data_client: UnifiedDataClient | None = None,
+    ) -> None:
+        """Initialize the sheet and load player data.
+
+        Parameters
+        ----------
+        player:
+            The :class:`~baseball_data_lab.player.player.Player` this sheet is for.
+        season:
+            The season for which to create the summary.
+        data_client:
+            Optional :class:`~baseball_data_lab.apis.unified_data_client.UnifiedDataClient`
+            instance used to fetch data. A default client is created when ``None``.
+        """
+
+        super().__init__(season, data_client)
+        self.player = player
+        self.player.load_stats_for_season(season)
+        self.player.load_statcast_data(self.start_date, self.end_date)
+


### PR DESCRIPTION
## Summary
- add `PlayerSummarySheet` base to handle player initialization and stat loading
- derive `BatterSummarySheet` and `PitcherSummarySheet` from new base
- expose `PlayerSummarySheet` via summary_sheets package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9c636e538832697c14dd89bd17cfa